### PR TITLE
Add exception error code on App::returnError

### DIFF
--- a/App.php
+++ b/App.php
@@ -199,7 +199,7 @@ class App extends Extension {
           array('code' => $appCode, 'message' => $errorResponse->getFormattedMessage($replacementArray))
     ));
     $this->getResponse()->status($errorResponse->getHttpcode());
-    throw new Stop($errorResponse->getFormattedMessage($replacementArray));
+    throw new Stop($errorResponse->getFormattedMessage($replacementArray), $appCode);
   }
 
   public function errorHandler($e) {


### PR DESCRIPTION
This fix includes the error code value in the thrown exception on App::returnError function 